### PR TITLE
Support promises in default function

### DIFF
--- a/src/ask.js
+++ b/src/ask.js
@@ -8,11 +8,12 @@ async function getMockedAnswers(mockPrompts, prompts) {
 
     if (Object.hasOwnProperty.call(mockPrompts, prompt.name)) {
       answers[name] = mockPrompts[prompt.name]
+    } else if (typeof prompt.default === 'function') {
+      const res = prompt.default(answers)
+      // eslint-disable-next-line no-await-in-loop
+      answers[name] = res.then ? await res : res
     } else {
-      answers[name] =
-        typeof prompt.default === 'function'
-          ? prompt.default(answers)
-          : prompt.default
+      answers[name] = prompt.default
     }
 
     if (prompt.type === 'confirm' && typeof answers[name] === 'undefined') {

--- a/test/test.js
+++ b/test/test.js
@@ -121,11 +121,12 @@ test('mock prompts', async t => {
   const res = await copy('./fixture-mock', './dest-mock', {
     prompts: [
       { name: 'foo', type: 'confirm' },
-      { name: 'bar', type: 'confirm', default: false }
+      { name: 'bar', type: 'confirm', default: false },
+      { name: 'promise', default: async answers => 'foo-bar' }
     ],
     mockPrompts: {}
   })
-  t.deepEqual(res.meta.answers, { foo: true, bar: false })
+  t.deepEqual(res.meta.answers, { foo: true, bar: false, promise: 'foo-bar' })
 })
 
 test('glob option', async t => {


### PR DESCRIPTION
`validate` does resolve promises when the user enters an `async function`, I'd like to have this on `default`